### PR TITLE
add:实体类、Service层、Controller层代码架子的搭建

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 ### 说明：
-通过一个案例，仿写Spring框架，从而学习Spring框架
+通过一个案例，仿写Spring框架的核心内容，从而学习Spring框架
 
 #### Init (2020-08-05):
 - 架子搭建完毕~
+
+#### 0.1 (2020-08-06):
+实体类、Service层、Controller层代码架子的搭建
+- 1.增加了`entity` 包含了`bo`和`dto`
+    - BO: 两个业务对象，头部banner条和商品类别。
+    - DTO: 两个数据传输对象，一个是为了首页同时返回的头部banner条和商品类别，另一个是统一返回结果Result.java。
+    - Result.java ，使用泛型类，方便返回不同类型的结果。
+- 2.增加了`service`层,包含了`solo`和`combine`包
+    - solo中分别是两个业务对象的增删改查的实现（伪实现）。
+    - combine中是主页所展示的内容的实现（伪实现）。
+- 3.增加了controller层，包含了`frontend包`和`DispatcherServlet.java`
+    - frontend包下的功能主要是实现主页内容，和管理员才能操作(superadmin包下)的增删改查。
+    - 通过DispatcherServlet.java进行请求的统一拦截。根据`request path`和`request method`来执行不同的方法。

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.dxh</groupId>
-    <artifactId>simpleframework</artifactId>
+    <artifactId>DxhFrameWork</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <properties>

--- a/src/main/java/com/dxh/HelloServlet.java
+++ b/src/main/java/com/dxh/HelloServlet.java
@@ -1,5 +1,6 @@
 package com.dxh;
 
+import com.dxh.entity.bo.HeadLine;
 import lombok.extern.slf4j.Slf4j;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -13,10 +14,27 @@ import java.io.IOException;
 public class HelloServlet extends HttpServlet {
 
     @Override
+    public void init() throws ServletException {
+        System.out.println("初始化~~");
+    }
+
+    @Override
+    protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        System.out.println("执行了doGet方法~");
+        doGet(req, resp);
+    }
+
+    @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         String name = "我的简易框架";
         log.debug("name is :" + name);
         req.setAttribute("name",name);
         req.getRequestDispatcher("/WEB-INF/jsp/hello.jsp").forward(req,resp);
+        HeadLine headLine = new HeadLine();
+    }
+
+    @Override
+    public void destroy() {
+        System.out.println("打印destroy~~");
     }
 }

--- a/src/main/java/com/dxh/controller/DispatcherServlet.java
+++ b/src/main/java/com/dxh/controller/DispatcherServlet.java
@@ -1,0 +1,34 @@
+package com.dxh.controller;
+
+import com.dxh.controller.frontend.MainPageController;
+import com.dxh.controller.frontend.superadmin.HeadLineOperationController;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author https://github.com/CoderXiaohui
+ * @Description
+ * 1. 拦截所有请求
+ * 2. 解析所有请求
+ * 3. 派发给对应的Controller的方法进行处理
+ * @Date 2020-08-06 00:33
+ */
+@WebServlet("/")
+public class DispatcherServlet extends HttpServlet {
+    @Override
+    protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        //假如访问 http://127.0.0.1:8080/DxhFrameWork/find/getMainInfo
+        System.out.println("request path is " + req.getServletPath()); // request path is /find/getMainInfo
+        System.out.println("request method is " + req.getMethod()); // request method is GET
+        if(req.getServletPath().equals("/frontend/getMainPageInfo") && req.getMethod().equals("GET")){
+            new MainPageController().getMainPageInfo(req, resp);
+        }else if(req.getServletPath().equals("/superadmin/addHeadLine") && req.getMethod().equals("POST")){
+            new HeadLineOperationController().addHeadLine(req, resp);
+        }
+    }
+}

--- a/src/main/java/com/dxh/controller/frontend/MainPageController.java
+++ b/src/main/java/com/dxh/controller/frontend/MainPageController.java
@@ -1,0 +1,21 @@
+package com.dxh.controller.frontend;
+
+import com.dxh.entity.dto.MainPageInfoDTO;
+import com.dxh.entity.dto.Result;
+import com.dxh.service.combine.HeadLineShopCategoryCombineService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author https://github.com/CoderXiaohui
+ * @Description
+ * @Date 2020-08-06 00:47
+ */
+public class MainPageController {
+    private HeadLineShopCategoryCombineService headLineShopCategoryCombineService;
+
+    public Result<MainPageInfoDTO> getMainPageInfo(HttpServletRequest req, HttpServletResponse resp){
+        return headLineShopCategoryCombineService.getMainPageInfo();
+    }
+}

--- a/src/main/java/com/dxh/controller/frontend/superadmin/HeadLineOperationController.java
+++ b/src/main/java/com/dxh/controller/frontend/superadmin/HeadLineOperationController.java
@@ -1,0 +1,43 @@
+package com.dxh.controller.frontend.superadmin;
+
+import com.dxh.entity.bo.HeadLine;
+import com.dxh.entity.dto.Result;
+import com.dxh.service.solo.HeadLineService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+
+/**
+ * @author https://github.com/CoderXiaohui
+ * @Description
+ * @Date 2020-08-06 00:49
+ */
+public class HeadLineOperationController {
+    private HeadLineService headLineService;
+
+    public Result<Boolean> addHeadLine(HttpServletRequest req, HttpServletResponse resp){
+        //TODO：参数校验、请求参数转化
+        return headLineService.addHeadLine(new HeadLine());
+    }
+
+    public Result<Boolean> removeHeadLine(HttpServletRequest req, HttpServletResponse resp){
+        //TODO：参数校验、请求参数转化
+       return headLineService.removeHeadLine(1);
+    }
+
+    public Result<Boolean> modifyHeadLine(HttpServletRequest req, HttpServletResponse resp){
+        //TODO：参数校验、请求参数转化
+        return headLineService.modifyHeadLine(new HeadLine());
+    }
+
+    public Result<HeadLine> queryHeadLineById(HttpServletRequest req, HttpServletResponse resp){
+        //TODO：参数校验、请求参数转化
+        return headLineService.queryHeadLineById(1);
+    }
+
+    public Result<List<HeadLine>> queryHeadLine(HttpServletRequest req, HttpServletResponse resp){
+        //TODO：参数校验、请求参数转化
+        return headLineService.queryHeadLine(null,1,100);
+    }
+}

--- a/src/main/java/com/dxh/controller/frontend/superadmin/ShopCategoryOperationController.java
+++ b/src/main/java/com/dxh/controller/frontend/superadmin/ShopCategoryOperationController.java
@@ -1,0 +1,44 @@
+package com.dxh.controller.frontend.superadmin;
+
+import com.dxh.entity.bo.HeadLine;
+import com.dxh.entity.bo.ShopCategory;
+import com.dxh.entity.dto.Result;
+import com.dxh.service.solo.ShopCategoryService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+
+/**
+ * @author https://github.com/CoderXiaohui
+ * @Description
+ * @Date 2020-08-06 00:53
+ */
+public class ShopCategoryOperationController {
+    private ShopCategoryService shopCategoryService;
+
+    public Result<Boolean> addShopCategory(HttpServletRequest req, HttpServletResponse resp){
+        //TODO：参数校验、请求参数转化
+        return shopCategoryService.addShopCategory(new ShopCategory());
+    }
+
+    public Result<Boolean> removeShopCategory(HttpServletRequest req, HttpServletResponse resp){
+        //TODO：参数校验、请求参数转化
+        return shopCategoryService.removeShopCategory(1);
+    }
+
+    public Result<Boolean> modifyShopCategory(HttpServletRequest req, HttpServletResponse resp){
+        //TODO：参数校验、请求参数转化
+        return shopCategoryService.modifyShopCategory(new ShopCategory());
+    }
+
+    public Result<HeadLine> queryShopCategoryById(HttpServletRequest req, HttpServletResponse resp){
+        //TODO：参数校验、请求参数转化
+        return shopCategoryService.queryShopCategoryById(1);
+    }
+
+    public Result<List<HeadLine>> queryShopCategory(HttpServletRequest req, HttpServletResponse resp){
+        //TODO：参数校验、请求参数转化
+        return shopCategoryService.queryShopCategory(null,1,100);
+    }
+}

--- a/src/main/java/com/dxh/entity/bo/HeadLine.java
+++ b/src/main/java/com/dxh/entity/bo/HeadLine.java
@@ -1,0 +1,44 @@
+package com.dxh.entity.bo;
+
+import lombok.Data;
+import java.util.Date;
+
+/**
+ * 头部banner条
+ */
+@Data
+public class HeadLine {
+    /**
+     * PrimaryKey
+     */
+    private Long lineId;
+
+    /**
+     * 头条名称
+     */
+    private String lineName;
+    /**
+     * 头条链接地址
+     */
+    private String lineLink;
+    /**
+     * 头条图片
+     */
+    private String lineImg;
+    /**
+     * 优先级
+     */
+    private String priority;
+    /**
+     * 可用性：0不可用 1可用
+     */
+    private Integer enableStatus;
+    /**
+     * 创建时间
+     */
+    private Date createTime;
+    /**
+     * 最后修改时间
+     */
+    private Date lastEditTime;
+}

--- a/src/main/java/com/dxh/entity/bo/ShopCategory.java
+++ b/src/main/java/com/dxh/entity/bo/ShopCategory.java
@@ -1,0 +1,45 @@
+package com.dxh.entity.bo;
+
+import lombok.Data;
+
+import java.util.Date;
+
+/**
+ * 商品类别
+ */
+@Data
+public class ShopCategory {
+    /**
+     * PrimaryKey
+     */
+    private Long shopCategoryId;
+    /**
+     * 类别名称
+     */
+    private String ShopCategoryName;
+    /**
+     * 类别描述
+     */
+    private String ShopCategoryDesc;
+    /**
+     * 类别图片地址
+     */
+    private String ShopCategoryImg;
+    /**
+     * 优先级
+     */
+    private Integer priority;
+    /**
+     * 创建时间
+     */
+    private Date createTime;
+    /**
+     * 最后修改时间
+     */
+    private Date lastEditTime;
+    /**
+     * 父类别
+     */
+    private ShopCategory parent;
+
+}

--- a/src/main/java/com/dxh/entity/dto/MainPageInfoDTO.java
+++ b/src/main/java/com/dxh/entity/dto/MainPageInfoDTO.java
@@ -1,0 +1,18 @@
+package com.dxh.entity.dto;
+
+import com.dxh.entity.bo.HeadLine;
+import com.dxh.entity.bo.ShopCategory;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * @author https://github.com/CoderXiaohui
+ * @Description
+ * @Date 2020-08-05 23:59
+ */
+@Data
+public class MainPageInfoDTO {
+    private List<HeadLine> headLineList;
+    private List<ShopCategory> shopCategoryList;
+}

--- a/src/main/java/com/dxh/entity/dto/Result.java
+++ b/src/main/java/com/dxh/entity/dto/Result.java
@@ -1,0 +1,26 @@
+package com.dxh.entity.dto;
+
+import lombok.Data;
+
+/**
+ * @author https://github.com/CoderXiaohui
+ * @Description
+ * @Date 2020-08-05 23:47
+ */
+@Data
+public class Result<T> {
+    /**
+     * 本次请求状态码，200表示成功
+     */
+    private int code;
+
+    /**
+     * 本次请求的详情
+     */
+    private String msg;
+
+    /**
+     * 本次请求的返回结果集
+     */
+    private T data;
+}

--- a/src/main/java/com/dxh/service/combine/HeadLineShopCategoryCombineService.java
+++ b/src/main/java/com/dxh/service/combine/HeadLineShopCategoryCombineService.java
@@ -1,0 +1,12 @@
+package com.dxh.service.combine;
+
+import com.dxh.entity.dto.MainPageInfoDTO;
+import com.dxh.entity.dto.Result;
+
+public interface HeadLineShopCategoryCombineService {
+    /**
+     * 主页所展示的内容
+     * @return
+     */
+    Result<MainPageInfoDTO> getMainPageInfo();
+}

--- a/src/main/java/com/dxh/service/combine/impl/HeadLineShopCategoryCombineServiceImpl.java
+++ b/src/main/java/com/dxh/service/combine/impl/HeadLineShopCategoryCombineServiceImpl.java
@@ -1,0 +1,45 @@
+package com.dxh.service.combine.impl;
+
+import com.dxh.entity.bo.HeadLine;
+import com.dxh.entity.bo.ShopCategory;
+import com.dxh.entity.dto.MainPageInfoDTO;
+import com.dxh.entity.dto.Result;
+import com.dxh.service.combine.HeadLineShopCategoryCombineService;
+import com.dxh.service.solo.HeadLineService;
+import com.dxh.service.solo.ShopCategoryService;
+
+import java.util.List;
+
+/**
+ * @author https://github.com/CoderXiaohui
+ * @Description
+ * @Date 2020-08-06 00:00
+ */
+public class HeadLineShopCategoryCombineServiceImpl implements HeadLineShopCategoryCombineService {
+    private HeadLineService headLineService;
+    private ShopCategoryService shopCategoryService;
+
+    /**
+     * 首页需要的数据
+     * @return
+     */
+    @Override
+    public Result<MainPageInfoDTO> getMainPageInfo() {
+        //1.获取头条列表 (因为是首页，所以查询条件设置为可用的，第1页，显示4条)
+        HeadLine headLineCondition = new HeadLine();
+        headLineCondition.setEnableStatus(1);
+        Result<List<HeadLine>> headLineList = headLineService.queryHeadLine(headLineCondition, 1, 4);
+        //2.获取店铺类别列表 (获取所有的ShopCategory.parent为Null的数据，第一页，每页显示100个)
+        ShopCategory shopCategoryCondition = new ShopCategory();
+        Result<List<HeadLine>> shopCategoryList = shopCategoryService.queryShopCategory(shopCategoryCondition, 1, 100);
+        //3.合并并返回
+        Result<MainPageInfoDTO> result = mergeMainPageInfoResult(headLineList,shopCategoryList);
+        return result;
+    }
+
+    private Result<MainPageInfoDTO> mergeMainPageInfoResult(Result<List<HeadLine>> headLineList, Result<List<HeadLine>> shopCategoryList) {
+        return null;
+    }
+
+
+}

--- a/src/main/java/com/dxh/service/solo/HeadLineService.java
+++ b/src/main/java/com/dxh/service/solo/HeadLineService.java
@@ -1,0 +1,18 @@
+package com.dxh.service.solo;
+
+import com.dxh.entity.bo.HeadLine;
+import com.dxh.entity.dto.Result;
+
+import java.util.List;
+
+public interface HeadLineService {
+    Result<Boolean> addHeadLine(HeadLine headLine);
+
+    Result<Boolean> removeHeadLine(int headLineId);
+
+    Result<Boolean> modifyHeadLine(HeadLine headLine);
+
+    Result<HeadLine> queryHeadLineById(int headLineId);
+
+    Result<List<HeadLine>> queryHeadLine(HeadLine headLineCondition,int pageIndex,int pageSize);
+}

--- a/src/main/java/com/dxh/service/solo/ShopCategoryService.java
+++ b/src/main/java/com/dxh/service/solo/ShopCategoryService.java
@@ -1,0 +1,19 @@
+package com.dxh.service.solo;
+
+import com.dxh.entity.bo.HeadLine;
+import com.dxh.entity.bo.ShopCategory;
+import com.dxh.entity.dto.Result;
+
+import java.util.List;
+
+public interface ShopCategoryService {
+    Result<Boolean> addShopCategory(ShopCategory shopCategory);
+
+    Result<Boolean> removeShopCategory(int shopCategoryId);
+
+    Result<Boolean> modifyShopCategory(ShopCategory shopCategory);
+
+    Result<HeadLine> queryShopCategoryById(int shopCategoryId);
+
+    Result<List<HeadLine>> queryShopCategory(ShopCategory shopCategoryCondition, int pageIndex, int pageSize);
+}

--- a/src/main/java/com/dxh/service/solo/impl/HeadLineServiceImpl.java
+++ b/src/main/java/com/dxh/service/solo/impl/HeadLineServiceImpl.java
@@ -1,0 +1,39 @@
+package com.dxh.service.solo.impl;
+
+import com.dxh.entity.bo.HeadLine;
+import com.dxh.entity.dto.Result;
+import com.dxh.service.solo.HeadLineService;
+
+import java.util.List;
+
+/**
+ * @author https://github.com/CoderXiaohui
+ * @Description
+ * @Date 2020-08-05 23:56
+ */
+public class HeadLineServiceImpl implements HeadLineService {
+    @Override
+    public Result<Boolean> addHeadLine(HeadLine headLine) {
+        return null;
+    }
+
+    @Override
+    public Result<Boolean> removeHeadLine(int headLineId) {
+        return null;
+    }
+
+    @Override
+    public Result<Boolean> modifyHeadLine(HeadLine headLine) {
+        return null;
+    }
+
+    @Override
+    public Result<HeadLine> queryHeadLineById(int headLineId) {
+        return null;
+    }
+
+    @Override
+    public Result<List<HeadLine>> queryHeadLine(HeadLine headLineCondition, int pageIndex, int pageSize) {
+        return null;
+    }
+}

--- a/src/main/java/com/dxh/service/solo/impl/ShopCategoryServiceImpl.java
+++ b/src/main/java/com/dxh/service/solo/impl/ShopCategoryServiceImpl.java
@@ -1,0 +1,40 @@
+package com.dxh.service.solo.impl;
+
+import com.dxh.entity.bo.HeadLine;
+import com.dxh.entity.bo.ShopCategory;
+import com.dxh.entity.dto.Result;
+import com.dxh.service.solo.ShopCategoryService;
+
+import java.util.List;
+
+/**
+ * @author https://github.com/CoderXiaohui
+ * @Description
+ * @Date 2020-08-05 23:56
+ */
+public class ShopCategoryServiceImpl implements ShopCategoryService {
+    @Override
+    public Result<Boolean> addShopCategory(ShopCategory shopCategory) {
+        return null;
+    }
+
+    @Override
+    public Result<Boolean> removeShopCategory(int shopCategoryId) {
+        return null;
+    }
+
+    @Override
+    public Result<Boolean> modifyShopCategory(ShopCategory shopCategory) {
+        return null;
+    }
+
+    @Override
+    public Result<HeadLine> queryShopCategoryById(int shopCategoryId) {
+        return null;
+    }
+
+    @Override
+    public Result<List<HeadLine>> queryShopCategory(ShopCategory shopCategoryCondition, int pageIndex, int pageSize) {
+        return null;
+    }
+}


### PR DESCRIPTION
实体类、Service层、Controller层代码架子的搭建

- 1.增加了`entity` 包含了`bo`和`dto`
    - BO: 两个业务对象，头部banner条和商品类别。
    - DTO: 两个数据传输对象，一个是为了首页同时返回的头部banner条和商品类别，另一个是统一返回结果Result.java。
    - Result.java ，使用泛型类，方便返回不同类型的结果。
- 2.增加了`service`层,包含了`solo`和`combine`包
    - solo中分别是两个业务对象的增删改查的实现（伪实现）。
    - combine中是主页所展示的内容的实现（伪实现）。
- 3.增加了controller层，包含了`frontend包`和`DispatcherServlet.java`
    - frontend包下的功能主要是实现主页内容，和管理员才能操作(superadmin包下)的增删改查。
    - 通过DispatcherServlet.java进行请求的统一拦截。根据`request path`和`request method`来执行不同的方法。